### PR TITLE
Allow to download files without description.

### DIFF
--- a/xgoogle/search.py
+++ b/xgoogle/search.py
@@ -237,7 +237,7 @@ class GoogleSearch(object):
     def _extract_result(self, result):
         title, url = self._extract_title_url(result)
         desc = self._extract_description(result)
-        if not title or not url or not desc:
+        if not title or not url:
             return None
         return SearchResult(title, url, desc)
 


### PR DESCRIPTION
Attachments without description are ignored by xgoogle, therefore can't be parsed or downloaded. The following patch fixes the issue.

My fork with applied changes: https://github.com/kenorb/xgoogle
